### PR TITLE
Add alternate sign-in method and federated login domain policies

### DIFF
--- a/ADMX/AdobeDC.admx
+++ b/ADMX/AdobeDC.admx
@@ -284,6 +284,54 @@
       <disabledValue><decimal value="0" /></disabledValue>
     </policy>
 
+    <!-- Use alternate sign-in methods [iAcroLoginType, iNGLCEFWorkflowEnabled] -->
+    <policy name="UseAlternateSignInMethod_Acrobat"
+        class="Machine"
+        displayName="$(string.UseAlternateSignInMethod_Acrobat)"
+        explainText="$(string.UseAlternateSignInMethod_Acrobat_Explain)"
+        key="SOFTWARE\Policies\Adobe\Adobe Acrobat\DC\FeatureLockDown"
+        value="UseAlternateSignInMethod"
+        presentation="$(presentation.UseAlternateSignInMethod_Acrobat_enum)">
+      <parentCategory ref="CloudConnectors_AcrobatCategory" />
+      <supportedOn ref="SupportedAcrobatReaderPolicies" />
+      <elements>
+        <enum id="UseAlternateSignInMethod_Acrobat_enum" valueName="AlternateSignInMethod">
+          <item displayName="$(string.UseAlternateSignInMethod_Acrobat_opt0)">
+            <value><decimal value="0" /></value>
+            <valueList>
+              <item key="SOFTWARE\Policies\Adobe\Adobe Acrobat\DC\FeatureLockDown" valueName="iAcroLoginType">
+                <value><decimal value="5" /></value>
+              </item>
+              <item key="SOFTWARE\Policies\Adobe\Adobe Acrobat\DC\FeatureLockDown" valueName="iNGLCEFWorkflowEnabled">
+                <value><delete /></value>
+              </item>
+            </valueList>
+          </item>
+          <item displayName="$(string.UseAlternateSignInMethod_Acrobat_opt1)">
+            <value><decimal value="1" /></value>
+            <valueList>
+              <item key="SOFTWARE\Policies\Adobe\Adobe Acrobat\DC\FeatureLockDown" valueName="iNGLCEFWorkflowEnabled">
+                <value><decimal value="0" /></value>
+              </item>
+              <item key="SOFTWARE\Policies\Adobe\Adobe Acrobat\DC\FeatureLockDown" valueName="iAcroLoginType">
+                <value><delete /></value>
+              </item>
+            </valueList>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+
+    <!-- Federated login domain - [login_domain] -->
+    <policy class="Machine" displayName="$(string.FederatedLoginDomain_Acrobat)" explainText="$(string.FederatedLoginDomain_Acrobat_Explain)" key="SOFTWARE\Policies\Adobe\NGL\AuthInfo"
+      name="FederatedLoginDomain_Acrobat" presentation="$(presentation.FederatedLoginDomain_Acrobat_text)">
+      <parentCategory ref="CloudConnectors_AcrobatCategory"/>
+      <supportedOn ref="SupportedAcrobatReaderPolicies"/>
+      <elements>
+        <text id="FederatedLoginDomain_Acrobat_text" valueName="login_domain" maxLength="2048" />
+      </elements>
+    </policy>
+
     <!-- OneDrive Connector - [bOneDriveConnectorEnabled] -->
     <policy class="Machine" displayName="$(string.bOneDriveConnectorEnabled_Acrobat)" explainText="$(string.bOneDriveConnectorEnabled_Acrobat_Explain)" key="SOFTWARE\Policies\Adobe\Adobe Acrobat\DC\FeatureLockDown\cServices"
       name="bOneDriveConnectorEnabled_Acrobat" valueName="bOneDriveConnectorEnabled">

--- a/ADMX/en-US/AdobeDC.adml
+++ b/ADMX/en-US/AdobeDC.adml
@@ -69,6 +69,15 @@
       <string id="bToggleSendACopy_Acrobat_Explain">Specifies whether to hide the Send a Copy button from the Fill &amp; Sign tool in Acrobat and Reader.&#10;&#10;Possible values include: 0: Hide the button. 1: Show the button.</string>
       <string id="bSuppressSignOut_Acrobat">Hide Sign Out Menu Item</string>
       <string id="bSuppressSignOut_Acrobat_Explain">Specifies whether the sign-in and sign-out Help menu item should be enabled.&#10;&#10;Possible values include: 0 or null: Don't disable the menu item. 1: Disable the Help menu item.</string>
+
+      <string id="UseAlternateSignInMethod_Acrobat">Use alternate sign-in method</string>
+      <string id="UseAlternateSignInMethod_Acrobat_Explain">Acrobat uses Chromium Embedded Framework (CEF) handle user sign-in from the desktop app, but CEF doesn't expose device information required by some identity providers or device-based conditional access policies, and can't access active SSO user sessions. Adobe has documented two alternate sign-in methods to work around these limitations. If this policy is enabled, you can select one of these options.&#10;&#10;External browser: Use the default web browser instead of the one embedded in the application.&#10;&#10;Legacy embedded engine: (HTTPS calls engine) Use the legacy embedded browser instead of CEF.&#10;&#10;If this policy is disabled or not configured, Acrobat will use its default Chromium Embedded Framework (CEF) for integrated user authentication.&#10;&#10;Ref: https://helpx.adobe.com/nz/acrobat/kb/cef-based-sign-in-not-working-with-azure-ad-conditional-access.html</string>
+      <string id="UseAlternateSignInMethod_Acrobat_opt0">External browser</string>
+      <string id="UseAlternateSignInMethod_Acrobat_opt1">Legacy embedded engine</string>
+
+      <string id="FederatedLoginDomain_Acrobat">Federated Login Domain</string>
+      <string id="FederatedLoginDomain_Acrobat_Explain">Specify a Federated ID login domain for Creative Cloud desktop applications, including Acrobat Pro. When a user signs in,they will be automatically redirected to your organization's identity provider for the claimed domain, instead of landing on Adobe's generic sign-in screen.&#10;&#10;To use this, your company must first claim the relevant domain in the Adobe Admin Console. You can claim more than one domain, but you can configure only one claimed domain on each machine. If you've claimed multiple domains, you can direct different machines to different domains.&#10;&#10;Note:&#10;-This setting is not compatible with external browser-based login&#10;-Users must authenticate with a Federated ID account&#10;&#10;Not currently supported: web services such as Acrobat Sign, Adobe Assets, and Adobe Libraries, mobile applications, Acrobat Reader, and Dreamweaver.&#10;&#10;Ref: https://community.adobe.com/announcements-623/enterprise-device-authentication-management-for-creative-cloud-desktop-apps-and-acrobat-pro-1634303</string>
+
       <string id="bOneDriveConnectorEnabled_Acrobat">OneDrive Connector</string>
       <string id="bOneDriveConnectorEnabled_Acrobat_Explain">Specifies whether to enable connection to the OneDrive cloud when bToggleWebConnectors is set to 1.&#10;&#10;Overrides a bToggleWebConnectors value of 1. Only supported on the Continuous track. Possible values include: 0: Disable connection to OneDrive 1: Enable connection to OneDrive</string>
       <string id="bTogglePrefsSync_Acrobat">Preferences Synchronization</string>
@@ -2076,6 +2085,12 @@
       <string id="bScanAppInstalled_User_Explain">Specifies whether to show the Adobe Scan mobile app promotion and link in the Home banner.&#10;&#10;Disable and lock both the App Center and Home banner with bToggleDCAppCenter under FeatureLockDown. Possible values include: 0: Promote the mobile app. 1: Don't promote the mobile app.</string>
     </stringTable>
     <presentationTable>
+      <presentation id="UseAlternateSignInMethod_Acrobat_enum">
+        <dropdownList defaultItem="0" refId="UseAlternateSignInMethod_Acrobat_enum">Alternate Sign-In Method:</dropdownList>
+      </presentation>
+      <presentation id="FederatedLoginDomain_Acrobat_text">
+        <textBox refId="FederatedLoginDomain_Acrobat_text"><label>Federated Login Domain:</label></textBox>
+      </presentation>
       <presentation id="iMIPCloud_Acrobat_enum">
         <dropdownList defaultItem="0" refId="iMIPCloud_Acrobat_enum">MIP Sovereign Cloud:</dropdownList>
       </presentation>

--- a/Documentation/adobe-settings-device.md
+++ b/Documentation/adobe-settings-device.md
@@ -21,6 +21,7 @@ Complete list of 154 unique Adobe DC settings (156 table entries where the same 
 | Document Cloud Services | ``bToggleAdobeDocumentServices`` | Enable Document Cloud services (except those controlled by other prefs). |
 | Document Cloud Storage | ``bToggleDocumentCloud`` | Enable Document Cloud storage. |
 | Dropbox Cloud Connector | ``bDropboxConnectorEnabled`` | Enable connection to the Dropbox cloud when bToggleWebConnectors is set to 1. |
+| Federated login domain | ``login_domain`` | Set the federated login domain so that the sign-in form automatically redirects to the organization's identity provider for the claimed domain, instead of Adobe's generic sign-in screen.<br />(See [Problem: CEF-based sign-in does not work with Azure Active Directory conditional access](https://community.adobe.com/announcements-623/enterprise-device-authentication-management-for-creative-cloud-desktop-apps-and-acrobat-pro-1634303)) |
 | Generative AI Technology | ``bEnableGentech`` | Enable generative AI features in Acrobat and Reader. |
 | Google Drive Connector | ``bGoogleDriveConnectorEnabled`` | Enable connection to the Google Drive cloud when bToggleWebConnectors is set to 1. |
 | Hide Fill & Sign Send a Copy Button | ``bToggleSendACopy`` | Hide the Send a Copy button from the Fill & Sign tool in Acrobat and Reader. |
@@ -29,6 +30,7 @@ Complete list of 154 unique Adobe DC settings (156 table entries where the same 
 | Preferences Synchronization | ``bTogglePrefsSync`` | Sync desktop preferences across signed-in devices. |
 | Services & Web-Plugin Updates | ``bUpdater`` | Web-plugin updates and cloud services. |
 | Third-Party Cloud Connectors | ``bToggleWebConnectors`` | Third-party cloud storage connectors (Continuous track). |
+| Use alternate sign-in method | ``iAcroLoginType, iNGLCEFWorkflowEnabled`` | Use an alternate browser for sign-ins to support conditional access policies and improve SSO.<br />(See [Problem: CEF-based sign-in does not work with Azure Active Directory conditional access](https://helpx.adobe.com/acrobat/kb/cef-based-sign-in-not-working-with-azure-ad-conditional-access.html)) |
 
 ### Context, Tools & Search
 

--- a/Documentation/data/policy-baseline.json
+++ b/Documentation/data/policy-baseline.json
@@ -3781,6 +3781,20 @@
       "controlType": "Toggle"
     },
     {
+      "name": "AlternateSignInMethod_Acrobat",
+      "class": "Machine",
+      "valueName": "iAcroLoginType, iNGLCEFWorkflowEnabled",
+      "key": "SOFTWARE\\Policies\\Adobe\\Adobe Acrobat\\DC\\FeatureLockDown",
+      "controlType": "Enum"
+    },
+   {
+      "name": "FederatedLoginDomain_Acrobat",
+      "class": "Machine",
+      "valueName": "login_domain",
+      "key": "SOFTWARE\\Policies\\Adobe\\NGL\\AuthInfo",
+      "controlType": "Text"
+    },
+    {
       "name": "bOneDriveConnectorEnabled_Acrobat",
       "class": "Machine",
       "valueName": "bOneDriveConnectorEnabled",

--- a/Documentation/data/policy-inventory.json
+++ b/Documentation/data/policy-inventory.json
@@ -127,6 +127,34 @@
       "regValDisabled": 0
     },
     {
+      "policyName": "AlternateSignInMethod_Acrobat",
+      "valueName": "iAcroLoginType, iNGLCEFWorkflowEnabled",
+      "friendlyName": "Use alternate sign-in method",
+      "category": "Cloud & Connectors",
+      "scope": "Device",
+      "product": "Acrobat",
+      "branch": "AcrobatPolicies",
+      "controlType": "Enum",
+      "summary": "Use an alternative sign-in method instead of the embedded Chromium browser.",
+      "details": "Possible values are External browser or Legacy embedded engine.",
+      "regValEnabled": null,
+      "regValDisabled": null
+    },
+    {
+      "policyName": "FederatedLoginDomain_Acrobat",
+      "valueName": "login_domain",
+      "friendlyName": "Federated Login Domain",
+      "category": "Cloud & Connectors",
+      "scope": "Device",
+      "product": "Acrobat",
+      "branch": "AcrobatPolicies",
+      "controlType": "Text",
+      "summary": "Specifies the federated login domain for Acrobat.",
+      "details": "Sets the federated login domain used for authentication in Acrobat.",
+      "regValEnabled": null,
+      "regValDisabled": null
+    },
+    {
       "policyName": "bOneDriveConnectorEnabled_Acrobat",
       "valueName": "bOneDriveConnectorEnabled",
       "friendlyName": "OneDrive Connector",


### PR DESCRIPTION
This PR adds two new Acrobat policies related to enterprise authentication and SSO scenarios:

**1. Alternate sign-in method:** Allows administrators to select an alternate sign-in workflow for compatibility with certain Conditional Access configurations and SSO deployments.
**2. Federated login domain:** Allows administrators to specify a federated login domain when Acrobat uses the integrated browser for authentication.

**Note**
The Alternate sign-in method policy maps to two registry values. I wasn't certain how you'd prefer that relationship to be represented in the generated documentation and value-definition files, so I currently list both values as a comma-separated entry. If there's a preferred format used elsewhere in the project, I'm happy to update it.